### PR TITLE
fix: add missing deps, remove redundant test-requirements.txt

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "k3proc",
     "playwright",
     "Pillow",
+    "pygments",
 ]
 
 [project.urls]
@@ -41,6 +42,7 @@ dev = [
     "ruff",
     "coverage",
     "k3ut",
+    "numpy",
     "scikit-image",
 ]
 publish = [

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,1 +1,0 @@
-scikit-image


### PR DESCRIPTION
## Summary
- Add `pygments` to runtime dependencies (required by `syntax_highlight.py` but was missing)
- Add `numpy` to dev dependencies (required by `test_down2.py` but was missing)
- Remove `test-requirements.txt` (redundant with `pyproject.toml [dev]`)

## Test plan
- [x] `make test` — 14/14 passed
- [x] `make lint` — all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)